### PR TITLE
Fix Val array bounds

### DIFF
--- a/otg.gpc
+++ b/otg.gpc
@@ -134,8 +134,9 @@ int Mod3[4];
 
 
 // Edit Menu /Editable Variables/Values [3] For 3 Profiles
-int Val1[23];
-int Val2[23];
+// Editable recoil arrays (0-23)
+int Val1[24];
+int Val2[24];
  
 //int Val1[] = {43, 0, 47, 44, 46, 46, 47, 54, 52, 52, 55, 57, 57, 60, 47, 44, 50, 47, 49, 7, 61, 50, 0}
 //int Val2[] = {-5, 0, -3, -6, -5, -5, -4, -6, -7, -8, -2, -4, -5, 6, 0, -2, -2, -1, -3, 0, -2, -2, 0}


### PR DESCRIPTION
## Summary
- allocate 24 slots for recoil value arrays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855972172ac832f99cde3140af4c444